### PR TITLE
Superseded: Add clone traffic chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,3 +172,11 @@ This scaffold focuses on:
 - Backend extensibility
 
 This scaffold does not yet implement a production-grade GPU training kernel. It establishes the module boundaries and execution flow needed to add those pieces incrementally.
+
+---
+
+## Clone traffic
+
+![Clone traffic](https://raw.githubusercontent.com/nikolareljin/stats/main/charts/finetorch.svg)
+
+_Updated daily. Total and unique cloners over the last 14 days._


### PR DESCRIPTION
## Summary

- Add the clone traffic SVG chart from nikolareljin/stats to the README.

## Validation

- Verified the stats SVG exists at charts/finetorch.svg before updating the README.
- Ran git diff --check for the README change.